### PR TITLE
Add options to set position of notification (Top/Bottom)

### DIFF
--- a/Objective-C/MPGNotification/MPGNotification.h
+++ b/Objective-C/MPGNotification/MPGNotification.h
@@ -50,6 +50,12 @@ typedef NS_ENUM(NSInteger, MPGNotificationButtonConfigration) {
     MPGNotificationButtonConfigrationCloseButton
 };
 
+// Sets the notification position.
+typedef NS_ENUM(NSInteger, MPGNotificationPosition) {
+    MPGNotificationPositionTop    = 0,
+    MPGNotificationPositionBottom
+};
+
 // Block to handle button presses
 typedef void (^MPGNotificationButtonHandler)(MPGNotification *notification, NSInteger buttonIndex);
 
@@ -92,6 +98,9 @@ typedef void (^MPGNotificationDismissHandler)(MPGNotification *notification);
 
 // Used to specify the type of animation that the notification should use to show and dismiss.
 @property (nonatomic) MPGNotificationAnimationType animationType;
+
+// Used to specify the notification position.
+@property (nonatomic) MPGNotificationPosition positionType;
 
 // Sets the button handler block directly; is also be set indirectly by calling showWithButtonHandler:
 @property (nonatomic, copy) MPGNotificationButtonHandler buttonHandler;

--- a/Objective-C/MPGNotification/MPGNotification.m
+++ b/Objective-C/MPGNotification/MPGNotification.m
@@ -94,6 +94,9 @@ static const CGFloat kColorAdjustmentLight = 0.35;
     UIView *topSubview = [[window subviews] lastObject];
     CGRect notificationFrame = CGRectMake(0, 0, CGRectGetWidth(topSubview.bounds), kNotificationHeight);
     
+    // Set default position type.
+    self.positionType = MPGNotificationPositionTop;
+    
     self = [super initWithFrame:notificationFrame];
     if (self) {
         
@@ -517,6 +520,27 @@ static const CGFloat kColorAdjustmentLight = 0.35;
     
     // Called to display the initiliased notification on screen.
     
+    //Modify y origin of notification frame based on its position type.
+    switch (self.positionType) {
+        case MPGNotificationPositionTop: {
+            CGRect frame = self.frame;
+            frame.origin.y = 0;
+            self.frame = frame;
+            break;
+        }
+        case MPGNotificationPositionBottom:{
+            // If the App has a keyWindow, get it, else get the 'top'-most window in the App's hierarchy.
+            UIWindow *window = [self _topAppWindow];
+            
+            // Now get the 'top'-most object in that window and use its MaxY for positioning the notification.
+            UIView *topSubview = [[window subviews] lastObject];
+            CGRect frame = self.frame;
+            frame.origin.y = CGRectGetMaxY(topSubview.bounds) - kNotificationHeight;
+            self.frame = frame;
+            break;
+        }
+    }
+    
     self.notificationRevealed = YES;
     
     if (self.hostViewController) {
@@ -540,11 +564,15 @@ static const CGFloat kColorAdjustmentLight = 0.35;
     switch (self.animationType) {
         case MPGNotificationAnimationTypeLinear: {
             
-            // move notification off-screen
-            self.contentOffset = CGPointMake(0, CGRectGetHeight(self.bounds));
+            // move notification off-screen based on its position type.
+            CGRect frame = self.frame;
+            frame.origin.y = self.frame.origin.y + (kNotificationHeight * (self.positionType == MPGNotificationPositionTop ? -1 : 1));
+            self.frame = frame;
             
             [UIView animateWithDuration:kLinearAnimationTime animations:^{
-                self.contentOffset = CGPointZero;
+                CGRect frame = self.frame;
+                frame.origin.y = self.frame.origin.y - (kNotificationHeight * (self.positionType == MPGNotificationPositionTop ? -1 : 1));
+                self.frame = frame;
             } completion:^(BOOL finished) {
                 [self _startDismissTimerIfSet];
             }];
@@ -554,21 +582,27 @@ static const CGFloat kColorAdjustmentLight = 0.35;
             
         case MPGNotificationAnimationTypeDrop: {
             
-            self.backgroundView.center = CGPointMake(self.center.x,
-                                                     self.center.y - CGRectGetHeight(self.bounds));
+            // move notification off-screen based on its position type.
+            CGRect frame = self.backgroundView.frame;
+            frame.origin.y = frame.origin.y + (kNotificationHeight * (self.positionType == MPGNotificationPositionTop ? -1 : 1));
+            self.backgroundView.frame = frame;
             
             self.animator = [[UIDynamicAnimator alloc] initWithReferenceView:self];
             
+            //Set gravity behavior and its direction based on its position type.
             UIGravityBehavior* gravityBehavior = [[UIGravityBehavior alloc] initWithItems:@[self.backgroundView]];
+            CGVector gravityDirection = {0.0, (self.positionType == MPGNotificationPositionTop ? 1.0 : -1.0)};
+            [gravityBehavior setGravityDirection:gravityDirection];
             [self.animator addBehavior:gravityBehavior];
             
             CGFloat notificationWidth = CGRectGetWidth(self.bounds);
             CGFloat notificationHeight = CGRectGetHeight(self.bounds);
             
+            //Set collision behavior based on its position type.
             UICollisionBehavior* collisionBehavior = [[UICollisionBehavior alloc] initWithItems:@[self.backgroundView]];
             [collisionBehavior addBoundaryWithIdentifier:@"MPGNotificationBoundary"
-                                               fromPoint:CGPointMake(0, notificationHeight)
-                                                 toPoint:CGPointMake(notificationWidth, notificationHeight)];
+                                               fromPoint:CGPointMake(0, (self.positionType == MPGNotificationPositionTop ? notificationHeight : 0))
+                                                 toPoint:CGPointMake(notificationWidth, (self.positionType == MPGNotificationPositionTop ? notificationHeight : 0))];
             
             [self.animator addBehavior:collisionBehavior];
             
@@ -616,7 +650,10 @@ static const CGFloat kColorAdjustmentLight = 0.35;
             case MPGNotificationAnimationTypeDrop: {
                 
                 [UIView animateWithDuration:kLinearAnimationTime animations:^{
-                    self.contentOffset = CGPointMake(0, CGRectGetHeight(self.bounds));
+                    //Dismiss notification based on its position type.
+                    CGRect frame = self.frame;
+                    frame.origin.y = self.frame.origin.y + (kNotificationHeight * (self.positionType == MPGNotificationPositionTop ? -1 : 1));
+                    self.frame = frame;
                 } completion:^(BOOL finished){
                     [self _destroyNotification];
                 }];
@@ -624,9 +661,10 @@ static const CGFloat kColorAdjustmentLight = 0.35;
             }
                 
             case MPGNotificationAnimationTypeSnap: {
+                //Dismiss notification based on its position type.
                 self.animator = [[UIDynamicAnimator alloc] initWithReferenceView:self];
                 [self.animator setDelegate:self];
-                UISnapBehavior *snapBehaviour = [[UISnapBehavior alloc] initWithItem:self.backgroundView snapToPoint:CGPointMake(viewBounds.size.width, -74)];
+                UISnapBehavior *snapBehaviour = [[UISnapBehavior alloc] initWithItem:self.backgroundView snapToPoint:CGPointMake(viewBounds.size.width, (self.positionType == MPGNotificationPositionTop ? -74 : 140))];
                 snapBehaviour.damping = 0.75f;
                 [self.animator addBehavior:snapBehaviour];
                 break;

--- a/Objective-C/MPGNotificationDemo/MPGNotificationDemo.xcodeproj/project.xcworkspace/xcshareddata/MPGNotificationDemo.xccheckout
+++ b/Objective-C/MPGNotificationDemo/MPGNotificationDemo.xcodeproj/project.xcworkspace/xcshareddata/MPGNotificationDemo.xccheckout
@@ -10,29 +10,29 @@
 	<string>MPGNotificationDemo</string>
 	<key>IDESourceControlProjectOriginsDictionary</key>
 	<dict>
-		<key>EC5DE40B-D9AD-43CC-9B3B-7E5F055F92D1</key>
-		<string>https://github.com/xhzengAIB/MPGNotification.git</string>
+		<key>0B9B7BDC1D86B4F69FF0030DC94DEF03FE87B326</key>
+		<string>https://github.com/iNima/MPGNotification.git</string>
 	</dict>
 	<key>IDESourceControlProjectPath</key>
-	<string>Objective-C/MPGNotificationDemo/MPGNotificationDemo.xcodeproj/project.xcworkspace</string>
+	<string>Objective-C/MPGNotificationDemo/MPGNotificationDemo.xcodeproj</string>
 	<key>IDESourceControlProjectRelativeInstallPathDictionary</key>
 	<dict>
-		<key>EC5DE40B-D9AD-43CC-9B3B-7E5F055F92D1</key>
+		<key>0B9B7BDC1D86B4F69FF0030DC94DEF03FE87B326</key>
 		<string>../../../..</string>
 	</dict>
 	<key>IDESourceControlProjectURL</key>
-	<string>https://github.com/xhzengAIB/MPGNotification.git</string>
+	<string>https://github.com/iNima/MPGNotification.git</string>
 	<key>IDESourceControlProjectVersion</key>
-	<integer>110</integer>
+	<integer>111</integer>
 	<key>IDESourceControlProjectWCCIdentifier</key>
-	<string>EC5DE40B-D9AD-43CC-9B3B-7E5F055F92D1</string>
+	<string>0B9B7BDC1D86B4F69FF0030DC94DEF03FE87B326</string>
 	<key>IDESourceControlProjectWCConfigurations</key>
 	<array>
 		<dict>
 			<key>IDESourceControlRepositoryExtensionIdentifierKey</key>
 			<string>public.vcs.git</string>
 			<key>IDESourceControlWCCIdentifierKey</key>
-			<string>EC5DE40B-D9AD-43CC-9B3B-7E5F055F92D1</string>
+			<string>0B9B7BDC1D86B4F69FF0030DC94DEF03FE87B326</string>
 			<key>IDESourceControlWCCName</key>
 			<string>MPGNotification</string>
 		</dict>

--- a/Objective-C/MPGNotificationDemo/MPGNotificationDemo/Base.lproj/Main_iPad.storyboard
+++ b/Objective-C/MPGNotificationDemo/MPGNotificationDemo/Base.lproj/Main_iPad.storyboard
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="5056" systemVersion="13D65" targetRuntime="iOS.CocoaTouch.iPad" propertyAccessControl="none" useAutolayout="YES" initialViewController="OYc-3g-mQk">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6254" systemVersion="13E28" targetRuntime="iOS.CocoaTouch.iPad" propertyAccessControl="none" useAutolayout="YES" initialViewController="OYc-3g-mQk">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="3733"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6247"/>
     </dependencies>
     <scenes>
-        <!--View Controller - MPGNotification-->
+        <!--MPGNotification-->
         <scene sceneID="tne-QT-ifu">
             <objects>
                 <viewController id="BYZ-38-t0r" customClass="ViewController" sceneMemberID="viewController">
@@ -18,7 +19,6 @@
                         <subviews>
                             <segmentedControl opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="3tm-b0-bYd">
                                 <rect key="frame" x="20" y="224" width="728" height="29"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <segments>
                                     <segment title="Linear"/>
                                     <segment title="Drop"/>
@@ -27,79 +27,98 @@
                             </segmentedControl>
                             <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Animation Type" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gMu-dI-pTg">
                                 <rect key="frame" x="20" y="195" width="126" height="21"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                 <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Position Type" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hUt-ab-B31">
+                                <rect key="frame" x="20" y="263" width="100" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="In-App Notifications Written In" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7TU-30-CLj">
+                                <rect key="frame" x="217" y="89" width="334" height="27"/>
+                                <fontDescription key="fontDescription" name="HelveticaNeue-Light" family="Helvetica Neue" pointSize="25"/>
+                                <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="ObjectiveC and Swift" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4zC-EN-YAJ">
+                                <rect key="frame" x="20" y="130" width="728" height="36"/>
+                                <fontDescription key="fontDescription" name="HelveticaNeue-Medium" family="Helvetica Neue" pointSize="40"/>
+                                <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="6kk-Hm-lpD">
+                                <rect key="frame" x="20" y="186" width="728" height="1"/>
+                                <color key="backgroundColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
+                            </view>
+                            <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Y08-fs-9v3">
+                                <rect key="frame" x="20" y="80" width="728" height="1"/>
+                                <color key="backgroundColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
+                            </view>
+                            <segmentedControl opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="sgp-TT-Yaz">
+                                <rect key="frame" x="20" y="292" width="488" height="29"/>
+                                <segments>
+                                    <segment title="Top"/>
+                                    <segment title="Bottom"/>
+                                </segments>
+                            </segmentedControl>
                             <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Notification Settings" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hBd-1I-zbD">
-                                <rect key="frame" x="20" y="260" width="139" height="21"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <rect key="frame" x="20" y="336" width="139" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                 <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="x6Q-Qy-HQf">
-                                <rect key="frame" x="20" y="289" width="728" height="200"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <rect key="frame" x="20" y="365" width="728" height="200"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ifr-b7-YMV">
                                         <rect key="frame" x="10" y="50" width="708" height="1"/>
-                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                                     </view>
                                     <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Dt0-kh-iFP">
                                         <rect key="frame" x="10" y="100" width="708" height="1"/>
-                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                                     </view>
                                     <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="d9Q-vI-hhr">
                                         <rect key="frame" x="10" y="150" width="708" height="1"/>
-                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                                     </view>
                                     <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Icon" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9Da-qZ-Ui6">
                                         <rect key="frame" x="20" y="17" width="137" height="21"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Subtitle" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ekq-kJ-e7P">
                                         <rect key="frame" x="20" y="66" width="137" height="21"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="uQv-ub-efV">
                                         <rect key="frame" x="659" y="12" width="51" height="31"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                     </switch>
                                     <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="YLF-SR-gRf">
                                         <rect key="frame" x="659" y="61" width="51" height="31"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                     </switch>
                                     <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Button(s)" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0w3-Zq-MlF">
                                         <rect key="frame" x="20" y="116" width="137" height="21"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <stepper opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="2" translatesAutoresizingMaskIntoConstraints="NO" id="xZH-Ze-AI3">
                                         <rect key="frame" x="624" y="112" width="94" height="29"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                         <connections>
                                             <action selector="updateButtonCount:" destination="BYZ-38-t0r" eventType="valueChanged" id="Cy5-tu-wmH"/>
                                         </connections>
                                     </stepper>
                                     <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="0" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZUY-Fs-2b2">
                                         <rect key="frame" x="590" y="116" width="29" height="21"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <segmentedControl opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="2" translatesAutoresizingMaskIntoConstraints="NO" id="lIR-GQ-aFb">
                                         <rect key="frame" x="10" y="159" width="708" height="29"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <segments>
                                             <segment title="Red"/>
                                             <segment title="Green"/>
@@ -121,12 +140,10 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ckw-hb-eNU">
-                                <rect key="frame" x="20" y="497" width="728" height="50"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <rect key="frame" x="20" y="573" width="728" height="50"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="SIi-1W-g3D">
                                         <rect key="frame" x="20" y="10" width="688" height="30"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <state key="normal" title="Show Notification">
                                             <color key="titleColor" red="0.90588235289999997" green="0.23529411759999999" blue="0.23529411759999999" alpha="1" colorSpace="calibratedRGB"/>
                                             <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
@@ -143,30 +160,6 @@
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
                             </view>
-                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="In-App Notifications Written In" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7TU-30-CLj">
-                                <rect key="frame" x="217" y="89" width="334" height="27"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" name="HelveticaNeue-Light" family="Helvetica Neue" pointSize="25"/>
-                                <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="ObjectiveC and Swift" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4zC-EN-YAJ">
-                                <rect key="frame" x="20" y="130" width="728" height="36"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" name="HelveticaNeue-Medium" family="Helvetica Neue" pointSize="40"/>
-                                <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="6kk-Hm-lpD">
-                                <rect key="frame" x="20" y="186" width="728" height="1"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
-                            </view>
-                            <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Y08-fs-9v3">
-                                <rect key="frame" x="20" y="80" width="728" height="1"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
-                            </view>
                         </subviews>
                         <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                     </view>
@@ -176,6 +169,7 @@
                         <outlet property="buttonLabel" destination="ZUY-Fs-2b2" id="FdJ-5c-gWl"/>
                         <outlet property="colorChooser" destination="lIR-GQ-aFb" id="HAn-Xt-wYW"/>
                         <outlet property="iconSwitch" destination="uQv-ub-efV" id="8bW-dK-Kk0"/>
+                        <outlet property="positionType" destination="sgp-TT-Yaz" id="ebk-6M-HbA"/>
                         <outlet property="subtitleSwitch" destination="YLF-SR-gRf" id="qve-fd-ouI"/>
                     </connections>
                 </viewController>

--- a/Objective-C/MPGNotificationDemo/MPGNotificationDemo/Base.lproj/Main_iPhone.storyboard
+++ b/Objective-C/MPGNotificationDemo/MPGNotificationDemo/Base.lproj/Main_iPhone.storyboard
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="5056" systemVersion="13D65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="Od4-kX-p6x">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6254" systemVersion="13E28" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="Od4-kX-p6x">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="3733"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6247"/>
     </dependencies>
     <scenes>
-        <!--View Controller - MPGNotification-->
+        <!--MPGNotification-->
         <scene sceneID="ufC-wZ-h7g">
             <objects>
                 <viewController id="vXZ-lx-hvc" customClass="ViewController" sceneMemberID="viewController">
@@ -17,8 +18,7 @@
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <subviews>
                             <segmentedControl opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="YK6-18-Nnq">
-                                <rect key="frame" x="20" y="224" width="280" height="29"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <rect key="frame" x="20" y="189" width="280" height="29"/>
                                 <segments>
                                     <segment title="Linear"/>
                                     <segment title="Drop"/>
@@ -26,80 +26,66 @@
                                 </segments>
                             </segmentedControl>
                             <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Animation Style" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xO6-a1-d9x">
-                                <rect key="frame" x="20" y="195" width="183" height="21"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <rect key="frame" x="20" y="160" width="183" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Notification Settings" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nK0-3X-tLc">
                                 <rect key="frame" x="20" y="261" width="183" height="21"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4X9-zv-zUZ">
                                 <rect key="frame" x="20" y="290" width="280" height="200"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="rX9-X8-Dtk">
                                         <rect key="frame" x="20" y="50" width="260" height="1"/>
-                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                                     </view>
                                     <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Icon" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PXu-Rt-uVN">
                                         <rect key="frame" x="20" y="17" width="137" height="21"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="crN-AU-jnN">
                                         <rect key="frame" x="20" y="100" width="260" height="1"/>
-                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                                     </view>
                                     <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="F6d-cG-8wk">
                                         <rect key="frame" x="20" y="150" width="260" height="1"/>
-                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                                     </view>
                                     <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Subtitle" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="l8H-ji-iQs">
                                         <rect key="frame" x="20" y="66" width="137" height="21"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="cEk-k0-gRG">
                                         <rect key="frame" x="211" y="12" width="51" height="31"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                     </switch>
                                     <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="89K-LL-yBt">
                                         <rect key="frame" x="211" y="61" width="51" height="31"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                     </switch>
                                     <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Button(s)" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PWd-vk-UVj">
                                         <rect key="frame" x="20" y="116" width="137" height="21"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <stepper opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="2" translatesAutoresizingMaskIntoConstraints="NO" id="rE1-sI-Kq3">
                                         <rect key="frame" x="176" y="112" width="94" height="29"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                         <connections>
                                             <action selector="updateButtonCount:" destination="vXZ-lx-hvc" eventType="valueChanged" id="5lF-Du-ecK"/>
                                         </connections>
                                     </stepper>
                                     <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="0" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0zh-nT-KQ3">
                                         <rect key="frame" x="142" y="116" width="29" height="21"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <segmentedControl opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="2" translatesAutoresizingMaskIntoConstraints="NO" id="SKt-X2-ktD">
                                         <rect key="frame" x="20" y="159" width="250" height="29"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <segments>
                                             <segment title="Red"/>
                                             <segment title="Green"/>
@@ -122,11 +108,9 @@
                             </view>
                             <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="r0f-PL-R5x">
                                 <rect key="frame" x="20" y="498" width="280" height="50"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="XqS-Q0-0cm">
                                         <rect key="frame" x="20" y="10" width="240" height="30"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <state key="normal" title="Show Notification">
                                             <color key="titleColor" red="0.90588235289999997" green="0.23529411759999999" blue="0.23529411759999999" alpha="1" colorSpace="calibratedRGB"/>
                                             <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
@@ -144,29 +128,38 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="In-App Notifications Written In" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HW9-am-0Yh">
-                                <rect key="frame" x="20" y="101" width="286" height="21"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <rect key="frame" x="20" y="81" width="286" height="21"/>
                                 <fontDescription key="fontDescription" name="HelveticaNeue-Light" family="Helvetica Neue" pointSize="17"/>
                                 <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="ObjC &amp; Swift" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zdt-dJ-l83">
-                                <rect key="frame" x="20" y="122" width="286" height="43"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <rect key="frame" x="20" y="102" width="286" height="43"/>
                                 <fontDescription key="fontDescription" name="HelveticaNeue-Medium" family="Helvetica Neue" pointSize="30"/>
                                 <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="MWq-qv-rco">
-                                <rect key="frame" x="20" y="171" width="280" height="1"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <rect key="frame" x="20" y="151" width="280" height="1"/>
                                 <color key="backgroundColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
                             </view>
                             <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="zh7-tt-PKJ">
-                                <rect key="frame" x="20" y="86" width="280" height="1"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <rect key="frame" x="20" y="72" width="280" height="1"/>
                                 <color key="backgroundColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
                             </view>
+                            <segmentedControl opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="atm-Ng-EVF">
+                                <rect key="frame" x="112" y="225" width="188" height="29"/>
+                                <segments>
+                                    <segment title="Top"/>
+                                    <segment title="Bottom"/>
+                                </segments>
+                            </segmentedControl>
+                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Position Type" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TOp-Ce-rYa">
+                                <rect key="frame" x="20" y="228" width="92" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                         </subviews>
                         <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                     </view>
@@ -176,6 +169,7 @@
                         <outlet property="buttonLabel" destination="0zh-nT-KQ3" id="pSt-4D-9cO"/>
                         <outlet property="colorChooser" destination="SKt-X2-ktD" id="NUA-8s-X71"/>
                         <outlet property="iconSwitch" destination="cEk-k0-gRG" id="wxo-9t-KYx"/>
+                        <outlet property="positionType" destination="atm-Ng-EVF" id="KJf-hj-I7H"/>
                         <outlet property="showNotificationButton" destination="XqS-Q0-0cm" id="VlP-EW-vcn"/>
                         <outlet property="subtitleSwitch" destination="89K-LL-yBt" id="hGZ-A3-tBY"/>
                     </connections>

--- a/Objective-C/MPGNotificationDemo/MPGNotificationDemo/ViewController.h
+++ b/Objective-C/MPGNotificationDemo/MPGNotificationDemo/ViewController.h
@@ -21,6 +21,7 @@
 
 @property (weak, nonatomic) IBOutlet UIButton *showNotificationButton;
 @property (weak, nonatomic) IBOutlet UISegmentedControl *animationType;
+@property (weak, nonatomic) IBOutlet UISegmentedControl *positionType;
 @property (weak, nonatomic) IBOutlet UISwitch *iconSwitch;
 @property (weak, nonatomic) IBOutlet UISwitch *subtitleSwitch;
 @property (weak, nonatomic) IBOutlet UILabel *buttonLabel;

--- a/Objective-C/MPGNotificationDemo/MPGNotificationDemo/ViewController.m
+++ b/Objective-C/MPGNotificationDemo/MPGNotificationDemo/ViewController.m
@@ -99,6 +99,20 @@
             break;
     }
     
+    //Set the position of notification
+    switch ([_positionType selectedSegmentIndex]) {
+        case 0:
+            [notification setPositionType:MPGNotificationPositionTop];
+            break;
+            
+        case 1:
+            [notification setPositionType:MPGNotificationPositionBottom];
+            break;
+            
+        default:
+            break;
+    }
+    
     [notification show];
     [_showNotificationButton setEnabled:NO];
 }


### PR DESCRIPTION
Hi @toblerpwn ,

I wanted to show the notification at bottom of screen.
Sometimes we face with a situation where it would be better to show notification at the bottom for example when It should remain on screen for a period of time. In some advance example we can show some count down or similar things as a notification. So it should not cover other UIs at the top of the screen.

I added an option to set notification position type.
Now developers can decide about showing notification at top or bottom.

Changing the position was not enough because all show and dismiss animations were implemented based on top position. So I changed all of them to be suitable and aligned based on position of notification.
All three animations now are shown and dismissed from/to direction that is appropriate for top/bottom notification.

I attached some screenshots, too.
Please try it and tell me your opinion about that. I tried to write the code in a pattern to be in sync with other parts of the source.

Regards,
Nima Azimi

![pull01](https://cloud.githubusercontent.com/assets/4446420/6317149/60a31b8e-ba98-11e4-816e-4d0c13c6d53e.png)

![pull02](https://cloud.githubusercontent.com/assets/4446420/6317150/673d249e-ba98-11e4-9c03-b34601ec63cf.png)

![pull03](https://cloud.githubusercontent.com/assets/4446420/6317152/6cc0592c-ba98-11e4-8c94-a465dd25e367.png)

![pull04](https://cloud.githubusercontent.com/assets/4446420/6317154/710bf64e-ba98-11e4-91e6-a5d86c3dba5e.png)

