### PR TITLE
Only allow destroy method to be executed once per display of a MPGNotification

### DIFF
--- a/Objective-C/MPGNotification/MPGNotification.m
+++ b/Objective-C/MPGNotification/MPGNotification.m
@@ -75,6 +75,7 @@ static const CGFloat kColorAdjustmentLight = 0.35;
 // state
 @property (nonatomic) BOOL notificationRevealed;
 @property (nonatomic) BOOL notificationDragged;
+@property (nonatomic) BOOL notificationDestroyed;
 
 // other
 @property (nonatomic, strong) UIDynamicAnimator *animator;
@@ -524,7 +525,8 @@ static const CGFloat kColorAdjustmentLight = 0.35;
 - (void)_showNotification {
     
     // Called to display the initiliased notification on screen.
-    
+   
+    self.notificationDestroyed = NO; 
     self.notificationRevealed = YES;
     
     if (self.hostViewController) {
@@ -732,16 +734,20 @@ static const CGFloat kColorAdjustmentLight = 0.35;
 
 - (void)_destroyNotification {
     
-    if (self.hostViewController == nil) {
-        [[[[UIApplication sharedApplication] delegate] window] setWindowLevel:self.windowLevel];
+    if (!self.notificationDestroyed) {
+        self.notificationDestroyed = YES;
+        
+        if (self.hostViewController == nil) {
+            [[[[UIApplication sharedApplication] delegate] window] setWindowLevel:self.windowLevel];
+        }
+        
+        [self _dismissBlockHandler];
+        
+        self.animator.delegate = nil;
+        self.animator = nil;
+        
+        [self removeFromSuperview];
     }
-    
-    [self _dismissBlockHandler];
-    
-    self.animator.delegate = nil;
-    self.animator = nil;
-    
-    [self removeFromSuperview];
     
 }
 


### PR DESCRIPTION
This PR prevents the _destroyNotification method from being executed more than once per display of a MPGNotification.  

This is important if manually hiding notifications that are also set on a timer, since _destroyNotification will get called when manually hiding, then once again by the timer.  

Calling _destroyNotification twice causes issues with the status bar when showing multiple notifications at a time due to the Window Level being set in that method.  (May be related to #26)
