### PR TITLE
Bumped pod version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ MPGNotification
 
 MPGNotifications is an iOS control that allows you to display in-app interactive notifications that are fully customisable to suit your needs.
 
-Available via [Cocoapods](http://cocoapods.org/): `pod 'MPGNotification', '~> 1.1'`
+Available via [Cocoapods](http://cocoapods.org/): `pod 'MPGNotification', '~> 1.2.1'`
 
 ![MPGNotification Screenshot](https://s3.amazonaws.com/evilapples/stash/MPGNotification.png)
 


### PR DESCRIPTION
Noticed the pod version in the README is 1.1, but the latest available version is 1.2.1. This pull request simply bumps the pod version in the README.