### PR TITLE
Add MPGNotification to the window rather than subview of the window

### DIFF
--- a/Objective-C/MPGNotification/MPGNotification.m
+++ b/Objective-C/MPGNotification/MPGNotification.m
@@ -543,7 +543,7 @@ static const CGFloat kColorAdjustmentLight = 0.35;
         [[[[UIApplication sharedApplication] delegate] window] setWindowLevel:UIWindowLevelStatusBar+1];
         
         // add the notification to the screen
-        [window.subviews.lastObject addSubview:self];
+        [window addSubview:self];
         
     }
     


### PR DESCRIPTION
See https://github.com/MPGNotification/MPGNotification/issues/40 for a discussion of the issue.

After submitting this, I realised that the MPGNotification probably won't react to orientation changes now that it has been added directly to the window.

This can be resolved by registering for notifications of these orientation events and updating the MPGNotification view accordingly.
