### PR TITLE
Autoresizing masks to support interface orientation changes

### DIFF
--- a/Objective-C/MPGNotification/MPGNotification.m
+++ b/Objective-C/MPGNotification/MPGNotification.m
@@ -125,6 +125,9 @@ static const CGFloat kColorAdjustmentLight = 0.35;
         self.backgroundTapsEnabled = YES;
         self.swipeToDismissEnabled = YES;
         
+        // auto resizing for interface orientation change
+        self.autoresizingMask = UIViewAutoresizingFlexibleWidth;
+        self.backgroundView.autoresizingMask = UIViewAutoresizingFlexibleWidth;
     }
     return self;
 }


### PR DESCRIPTION
Added autoresizing masks for width in init method for proper resizing on interface orientation change.
Reference issue: https://github.com/MPGNotification/MPGNotification/issues/27
